### PR TITLE
Allow multiple projects to be loaded simultaneously

### DIFF
--- a/src/main/java/org/nmrfx/processor/gui/AtomBrowser.java
+++ b/src/main/java/org/nmrfx/processor/gui/AtomBrowser.java
@@ -416,7 +416,7 @@ public class AtomBrowser {
         final boolean useOrder = true;
         List<Peak> peaks = new ArrayList<>();
 
-        PeakList.peakListTable.values().stream().forEach(peakList -> {
+        PeakList.peakListTable().values().stream().forEach(peakList -> {
             if (Util.stringMatch(peakList.getName(), listPattern)) {
                 List<Peak> listPeaks = peakList.matchPeaks(matchStrings, useRegexp, useOrder);
                 peaks.addAll(listPeaks);

--- a/src/main/java/org/nmrfx/processor/gui/AtomController.java
+++ b/src/main/java/org/nmrfx/processor/gui/AtomController.java
@@ -221,7 +221,7 @@ public class AtomController implements Initializable, FreezeListener {
         );
         MenuItem getPPMItem = new MenuItem("Get Frozen PPM");
         getPPMItem.setOnAction(e -> {
-            ((AtomResonanceFactory) PeakDim.resFactory).assignFrozenAtoms("sim");
+            ((AtomResonanceFactory) PeakDim.resFactory()).assignFrozenAtoms("sim");
             atomTableView.refresh();
         }
         );

--- a/src/main/java/org/nmrfx/processor/gui/NOETableController.java
+++ b/src/main/java/org/nmrfx/processor/gui/NOETableController.java
@@ -90,7 +90,7 @@ public class NOETableController implements Initializable {
     public void initialize(URL url, ResourceBundle rb) {
         initToolBar();
         initTable();
-        noeSetMap = FXCollections.observableMap(NoeSet.NOE_SETS);
+        noeSetMap = FXCollections.observableMap(NoeSet.NOE_SETS());
         MapChangeListener<String, NoeSet> mapChangeListener = (MapChangeListener.Change<? extends String, ? extends NoeSet> change) -> {
             updateNoeSetMenu();
         };
@@ -100,7 +100,7 @@ public class NOETableController implements Initializable {
             updatePeakListMenu();
         };
 
-        PeakList.peakListTable.addListener(peakmapChangeListener);
+        PeakList.peakListTable().addListener(peakmapChangeListener);
         updateNoeSetMenu();
         updatePeakListMenu();
 
@@ -155,7 +155,7 @@ public class NOETableController implements Initializable {
     public void updatePeakListMenu() {
         peakListMenuButton.getItems().clear();
 
-        for (String peakListName : PeakList.peakListTable.keySet()) {
+        for (String peakListName : PeakList.peakListTable().keySet()) {
             MenuItem menuItem = new MenuItem(peakListName);
             menuItem.setOnAction(e -> {
                 extractPeakList(PeakList.get(peakListName));

--- a/src/main/java/org/nmrfx/processor/gui/PeakTableController.java
+++ b/src/main/java/org/nmrfx/processor/gui/PeakTableController.java
@@ -127,13 +127,13 @@ public class PeakTableController implements PeakMenuTarget, PeakListener, Initia
             updatePeakListMenu();
         };
 
-        PeakList.peakListTable.addListener(mapChangeListener);
+        PeakList.peakListTable().addListener(mapChangeListener);
     }
 
     public void updatePeakListMenu() {
         peakListMenuButton.getItems().clear();
 
-        for (String peakListName : PeakList.peakListTable.keySet()) {
+        for (String peakListName : PeakList.peakListTable().keySet()) {
             MenuItem menuItem = new MenuItem(peakListName);
             menuItem.setOnAction(e -> {
                 setPeakList(PeakList.get(peakListName));

--- a/src/main/java/org/nmrfx/processor/gui/StripController.java
+++ b/src/main/java/org/nmrfx/processor/gui/StripController.java
@@ -231,7 +231,7 @@ public class StripController implements ControllerTool {
                 itemPeakListMenuButton, peakLabel,
                 offsetLabel, offsetBox, rowLabel, rowBox);
 
-        PeakList.peakListTable.addListener(mapChangeListener);
+        PeakList.peakListTable().addListener(mapChangeListener);
         updatePeakListMenu();
         updateDatasetNames();
         StripItem item = new StripItem();
@@ -272,7 +272,7 @@ public class StripController implements ControllerTool {
         });
         itemPeakListMenuButton.getItems().add(emptyPeakListMenuItem);
 
-        for (String peakListName : PeakList.peakListTable.keySet()) {
+        for (String peakListName : PeakList.peakListTable().keySet()) {
             MenuItem menuItem = new MenuItem(peakListName);
             menuItem.setOnAction(e -> {
                 setPeakList(peakListName);

--- a/src/main/java/org/nmrfx/processor/gui/molecule/MoleculeCanvas.java
+++ b/src/main/java/org/nmrfx/processor/gui/molecule/MoleculeCanvas.java
@@ -25,7 +25,7 @@ public class MoleculeCanvas extends Canvas {
     List<CanvasMolecule> canvasMolecules = new ArrayList<>();
 
     public void setupMolecules() {
-        Molecule molecule = Molecule.activeMol;
+        Molecule molecule = Molecule.activeMol();
         if (molecule != null) {
             CanvasMolecule canvasMol = new CanvasMolecule();
             canvasMol.setMolName(molecule.getName());

--- a/src/main/java/org/nmrfx/project/GUIStructureProject.java
+++ b/src/main/java/org/nmrfx/project/GUIStructureProject.java
@@ -48,6 +48,18 @@ public class GUIStructureProject extends StructureProject {
         project.molecules.clear();
         newProject.peakLists.putAll(project.peakLists);
         project.peakLists.clear();
+        newProject.datasetList=project.datasetList;
+        newProject.peakListTable=project.peakListTable;
+        newProject.resFactory=project.resFactory;
+        newProject.peakPaths=project.peakPaths;
+        newProject.compoundMap.putAll(project.compoundMap);
+        newProject.activeMol = project.activeMol;
+        newProject.NOE_SETS.putAll(project.NOE_SETS);
+        newProject.ACTIVE_SET = project.ACTIVE_SET;
+        newProject.angleSets = project.angleSets;
+        newProject.activeSet = project.activeSet;
+        newProject.rdcSets = project.rdcSets;
+        newProject.activeRDCSet = project.activeRDCSet;
         return newProject;
     }
 
@@ -94,40 +106,51 @@ public class GUIStructureProject extends StructureProject {
     }
 
     public void loadGUIProject(Path projectDir) throws IOException, IllegalStateException, MoleculeIOException {
+        Project currentProject=getActive();
+        setActive();
+
         loadStructureProject(projectDir);
-        FileSystem fileSystem = FileSystems.getDefault();
 
-        String[] subDirTypes = {"windows"};
-        if (projectDir != null) {
-            for (String subDir : subDirTypes) {
-                Path subDirectory = fileSystem.getPath(projectDir.toString(), subDir);
-                if (Files.exists(subDirectory) && Files.isDirectory(subDirectory) && Files.isReadable(subDirectory)) {
-                    switch (subDir) {
-                        case "windows":
-                            loadWindows(subDirectory);
-                            break;
-                        default:
-                            throw new IllegalStateException("Invalid subdir type");
+        if (currentProject==this) {
+            FileSystem fileSystem = FileSystems.getDefault();
+
+            String[] subDirTypes = {"windows"};
+            if (projectDir != null) {
+                for (String subDir : subDirTypes) {
+                    Path subDirectory = fileSystem.getPath(projectDir.toString(), subDir);
+                    if (Files.exists(subDirectory) && Files.isDirectory(subDirectory) && Files.isReadable(subDirectory)) {
+                        switch (subDir) {
+                            case "windows":
+                                loadWindows(subDirectory);
+                                break;
+                            default:
+                                throw new IllegalStateException("Invalid subdir type");
+                        }
                     }
-                }
 
+                }
             }
         }
         this.projectDir = projectDir;
         PreferencesController.saveRecentProjects(projectDir.toString());
-
+        currentProject.setActive();
     }
 
     @Override
     public void saveProject() throws IOException {
+        Project currentProject=getActive();
+        setActive();
+
         if (projectDir == null) {
             throw new IllegalArgumentException("Project directory not set");
         }
         super.saveProject();
-        saveWindows(projectDir);
+        if(currentProject==this) {
+            saveWindows(projectDir);
+        }
         gitCommitOnThread();
         PreferencesController.saveRecentProjects(projectDir.toString());
-
+        currentProject.setActive();
     }
 
     void gitCommitOnThread() {

--- a/src/main/java/org/nmrfx/structure/chemistry/mol3D/MolSceneController.java
+++ b/src/main/java/org/nmrfx/structure/chemistry/mol3D/MolSceneController.java
@@ -170,7 +170,7 @@ public class MolSceneController implements Initializable, MolSelectionListener, 
             updatePeakListMenu();
         };
 
-        PeakList.peakListTable.addListener(mapChangeListener);
+        PeakList.peakListTable().addListener(mapChangeListener);
         updatePeakListMenu();
         modeMenuButton.getItems().add(numbersCheckBox);
         modeMenuButton.getItems().add(activeCheckBox);
@@ -690,7 +690,7 @@ public class MolSceneController implements Initializable, MolSelectionListener, 
     public void updatePeakListMenu() {
         peakListMenuButton.getItems().clear();
 
-        for (String peakListName : PeakList.peakListTable.keySet()) {
+        for (String peakListName : PeakList.peakListTable().keySet()) {
             MenuItem menuItem = new MenuItem(peakListName);
             menuItem.setOnAction(e -> {
                 PeakList peakList = PeakList.get(peakListName);


### PR DESCRIPTION
The pull request for nmrfxprocessor describes the aims and strategy. It is pasted below for reference.

In analystgui:

GUIStructureProject.replace method includes new project instance variables.

GUIStructureProject loadProject and saveProject methods updated to store the currently active project before making the owning object active, and then restore after the save or load is complete.

All references to original static variables have been updated to call the new methods instead.



---------- pull request message from nmrfxprocessor ----------

With our workflow, being able to easily access other projects (e.g. fragments of a larger molecule) would be highly enabling. The forthcoming pull requests are a suggestion for how this might be achieved. I appreciate you will probably be wary of this and so for this initial pull request the changes are minimal - if you agree with this approach then I can suggest some additional changes which facilitate this type of workflow.

The reason that it is not currently possible to load multiple projects is that there are a number of static variables which store project information which are set when a project is loaded and read from when a project is saved. In nmrfxprocessor these are:

Dataset.theFiles
PeakList.peakListTable
PeakDim.resFactory
PeakPath.peakPaths

I have changed these to be instances of a Project object, so they can be independently managed between projects.

Dataset.theFiles -> theProject.datasetList
PeakList.peakListTable -> theProject.peakListTable
PeakDim.resFactory -> theProject.resFactory
PeakPath.peakPaths -> theProject.peakPaths

The original static variables have been converted to static methods which return the relevant variable from the active project. For example:

private static HashMap<String, Dataset> theFiles = new HashMap<>();
Becomes:

private static HashMap<String, Dataset> theFiles () {
    return Project.getActive().datasetList;
}
And all references to Dataset.theFiles become Dataset.theFiles() .

The only other changes are in Project.java.

First, it is necessary that an active project is always return from Project.getActive(). If there is no activeProject, a new project is now created with the following precedence:

GUIStructureProject, StructureProject, GUIProject, Project

Finally, project.loadProject() and project.saveProject() store the currently active project before making the owning object active, and then restore after the save or load is complete.

In my testing, this allows me to load a project, and then (in Jython) do something like:

project1=Project("testproject1")
project1.loadProject(Paths.get("/Users/jan/soft/nmrfx/testproject1"))
project2=Project("testproject2")
project1.setActive()
project2.loadProject(Paths.get("/Users/jan/soft/nmrfx/testproject2"))

#access and modify peaklists, assignments etc. within each project

currentProject.saveProject()
subProject.saveProject()

